### PR TITLE
protecting code to exit nicely if it does not find required pattern of headers

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/dto/StompMessage.java
@@ -86,6 +86,9 @@ public class StompMessage {
             headers.add(new StompHeader(matcher.group(1), matcher.group(2)));
         }
 
+        if (!reader.hasNext("\n\n")) {
+            return new StompMessage(StompCommand.UNKNOWN, null, data);
+        }
         reader.skip("\n\n");
 
         reader.useDelimiter(TERMINATE_MESSAGE_SYMBOL);


### PR DESCRIPTION
protecting code to exit nicely incoming message  does not find required pattern at the end of headers \n\n